### PR TITLE
修复while continue中没有slepp造成无意义的循环引起CPU占满的问题

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "yzh52521/schedule",
+    "name": "gutink/schedule",
     "description": "task schedule,schedule,thinkphp schedule,任务调度",
     "keywords": [
         "schedule",

--- a/src/scheduling/ScheduleRunCommand.php
+++ b/src/scheduling/ScheduleRunCommand.php
@@ -153,6 +153,7 @@ class ScheduleRunCommand extends ThinkCommand
     {
         while (Carbon::now()->lte($this->startedAt->endOfMinute())) {
             if (!$event->shouldRepeatNow()) {
+                usleep(100000);
                 continue;
             }
             if ($event->runsInMaintenanceMode()) {
@@ -169,7 +170,6 @@ class ScheduleRunCommand extends ThinkCommand
             }
             $this->eventsRan = true;
         }
-        usleep(100000);
     }
 
     /**


### PR DESCRIPTION
如题，sleep放错了位置，导致while疯狂循环